### PR TITLE
Adding a file exists check

### DIFF
--- a/brilws/cli/brilcalc_lumi.py
+++ b/brilws/cli/brilcalc_lumi.py
@@ -55,6 +55,9 @@ def validate(optdict):
     if not result['-i'] and not result['-f'] and not result['-r'] and not result['--begin']:
         print ('Error: at least one time selection option in %s is required'%(','.join(['-i','-f','-r','--begin'])))
         sys.exit(0)
+    if result['-i'] and not os.path.exists(result['-i']):
+        print('Error: file %s does not exist.'%(result['-i']))
+        sys.exit(0)
     if result['--filedata'] and not result['--byls']:
         print ('Error: --filedata can only be used with --byls')
         sys.exit(0)            


### PR DESCRIPTION
This MR is inspired by running into this error twice within a month: https://cms-talk.web.cern.ch/t/valueerror-malformed-node-or-string-on-line-1-when-running-brilcalc/46454
This error is triggered if the json file from crab report passed to brilcalc lumi via the '-i' argument is missing. 

The python error is rather confusing so I propose to catch the error beforehand with a more human-friendly message. 

I am not entirely sure how to test this PR. I have managed to successfully build the brilcalc package locally but I am not entirely sure how to easily run it from the command line (not an expert in python development). Please let me know which tests need to be performed. 

